### PR TITLE
Bump semver due to incompatible oci-spec change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,14 +5,15 @@ license = "MIT OR Apache-2.0"
 name = "containers-image-proxy"
 readme = "README.md"
 repository = "https://github.com/containers/containers-image-proxy-rs"
-version = "0.8.0"
+version = "0.9.0"
 rust-version = "1.70.0"
 
 [dependencies]
 futures-util = "0.3.13"
 # NOTE when bumping this in a semver-incompatible way, because we re-export it you
 # must also bump the semver of this project.
-oci-spec = "0.8.0"
+# See also https://github.com/youki-dev/oci-spec-rs/pull/288
+oci-spec = "0.8.2"
 rustix = { version = "1.0", features = ["process", "fs", "net"] }
 serde = { features = ["derive"], version = "1.0.125" }
 serde_json = "1.0.64"


### PR DESCRIPTION
And we now hard require >= 0.8.2.

xref https://github.com/youki-dev/oci-spec-rs/pull/288